### PR TITLE
setFont(const GFXfont*) must update currentFont

### DIFF
--- a/src/DisplayWrapper.cpp
+++ b/src/DisplayWrapper.cpp
@@ -55,8 +55,12 @@ uint8_t DisplayWrapper::getStringWidth(const String& strUser){
 	return lcd.textWidth(strUser);
 }
 
+// Reports the height of the font that is actually selected. currentFont is
+// maintained by BOTH setFont() overloads; before the first setFont() call it is
+// still NULL, so fall back to the metric LovyanGFX holds for the live font
+// rather than dereferencing a null IFont*.
 uint8_t DisplayWrapper::getStringHeight(const String& strUser){
-	return lcd.fontHeight(currentFont);
+	return currentFont ? lcd.fontHeight(currentFont) : lcd.fontHeight();
 }
 
 void DisplayWrapper::drawRect(int16_t x, int16_t y, int16_t width, int16_t height){
@@ -119,6 +123,7 @@ void DisplayWrapper::setFont(int index){
 
 void DisplayWrapper::setFont(const GFXfont *fontData){
 	lcd.setFont(fontData);
+	currentFont = fontData;		// keep getStringHeight() in step
 }
 
 void DisplayWrapper::setFontIndex(int index){


### PR DESCRIPTION
`setFont(int)` records which font it selected in `currentFont`; `setFont(const GFXfont *)` does not. And `getStringHeight()` reports `lcd.fontHeight(currentFont)`.

So a font set through the pointer overload is drawn with, but measured against, whatever font the last `setFont(int)` happened to choose — width comes from the new font (`getStringWidth()` goes straight to `lcd.textWidth()`), height from the old one.

Nothing hit this before because every caller used the index overload. The Morserino-32 firmware now selects a scroll-area font by pointer, and gets row heights for an unrelated font: text ends up positioned off the bottom of the panel, and the layout silently depends on which indexed font was selected last.

```cpp
void DisplayWrapper::setFont(const GFXfont *fontData){
	lcd.setFont(fontData);
	currentFont = fontData;		// keep getStringHeight() in step
}
```

Also guards the pre-first-`setFont()` case while I'm in there: the constructor leaves `currentFont` as `NULL`, and `LGFXBase::fontHeight(const IFont*)` dereferences its argument to call `getDefaultMetric()`, so a `getStringHeight()` before any `setFont()` faults. It now falls back to the metric LovyanGFX already holds for the live font:

```cpp
return currentFont ? lcd.fontHeight(currentFont) : lcd.fontHeight();
```

No behaviour change for existing index-based callers — for those, `currentFont` and the live font are the same object either way.

Verified by building the Morserino-32 firmware (`pocketwroom` and `pocketwroom-accessibility` environments, ESP32-S3 + ST7789) against this branch.

Branched off `main` here rather than off my fork's, so this is just the one commit — my fork has drifted a fair way and none of the rest belongs in yours.
