### PR TITLE
Fix two silently-wrong API methods: string width and text alignment

### DIFF
--- a/include/DisplayWrapper.h
+++ b/include/DisplayWrapper.h
@@ -29,8 +29,8 @@ class DisplayWrapper {
 		void display();
 		void displayOff();
 		void drawHorizontalLine();
-		uint8_t getStringWidth(const String& usrStr);
-		uint8_t getStringHeight(const String& usrStr);
+		uint16_t getStringWidth(const String& usrStr);
+		uint16_t getStringHeight(const String& usrStr);
 		void drawRect(int16_t x, int16_t y, int16_t width, int16_t height);
 		void fillRect(int16_t x, int16_t y, int16_t width, int16_t height);
 		void drawHorizontalLine(int16_t x, int16_t y, int16_t length);
@@ -56,6 +56,7 @@ class DisplayWrapper {
 		int colorConvert(OLEDDISPLAY_COLOR color);
 		int color = TFT_WHITE;
 		const GFXfont *currentFont;
+		OLEDDISPLAY_TEXT_ALIGNMENT textAlign = TEXT_ALIGN_LEFT;
 		bool useTheme;
 		uint16_t fg, bg;
 

--- a/src/DisplayWrapper.cpp
+++ b/src/DisplayWrapper.cpp
@@ -51,7 +51,11 @@ void DisplayWrapper::displayOff(){
   lcd.sleep();
 }
 
-uint8_t DisplayWrapper::getStringWidth(const String& strUser){
+// uint16_t, not uint8_t: LovyanGFX's textWidth() returns int32_t, and a string
+// only has to reach 256 px to wrap. On a 320 px panel that is ~15 characters of
+// a 18 px monospace font, which is well inside one line - so the truncation was
+// reachable with ordinary text, and silent.
+uint16_t DisplayWrapper::getStringWidth(const String& strUser){
 	return lcd.textWidth(strUser);
 }
 
@@ -59,7 +63,7 @@ uint8_t DisplayWrapper::getStringWidth(const String& strUser){
 // maintained by BOTH setFont() overloads; before the first setFont() call it is
 // still NULL, so fall back to the metric LovyanGFX holds for the live font
 // rather than dereferencing a null IFont*.
-uint8_t DisplayWrapper::getStringHeight(const String& strUser){
+uint16_t DisplayWrapper::getStringHeight(const String& strUser){
 	return currentFont ? lcd.fontHeight(currentFont) : lcd.fontHeight();
 }
 
@@ -82,8 +86,21 @@ void DisplayWrapper::drawXbm(int16_t x, int16_t y, int16_t width, int16_t height
 	lcd.drawXBitmap(x, y, xbm, width, height, useTheme ? fg : TFT_WHITE, useTheme ? bg : TFT_BLACK);
 }
 
+// Map the ThingPulse alignment enum onto a LovyanGFX datum. CENTER centres
+// horizontally on x and keeps the top edge at y; CENTER_BOTH centres on both
+// axes - the same meaning the OLED library this wrapper emulates gives them.
+static lgfx::textdatum_t datumFor(OLEDDISPLAY_TEXT_ALIGNMENT a) {
+	switch (a) {
+		case TEXT_ALIGN_RIGHT:       return lgfx::top_right;
+		case TEXT_ALIGN_CENTER:      return lgfx::top_center;
+		case TEXT_ALIGN_CENTER_BOTH: return lgfx::middle_center;
+		case TEXT_ALIGN_LEFT:
+		default:                     return lgfx::top_left;
+	}
+}
+
 uint16_t DisplayWrapper::drawString(int16_t x, int16_t y, const String &text) {
-	lcd.setTextDatum(lgfx::top_left);
+	lcd.setTextDatum(datumFor(textAlign));
 	lcd.drawString(text.c_str(), x, y);
 	return lcd.textWidth(text.c_str());
 }
@@ -115,7 +132,11 @@ lgfx::LGFX_Device* DisplayWrapper::getLGFX(){
 }
 #endif
 
-void DisplayWrapper::setTextAlignment(OLEDDISPLAY_TEXT_ALIGNMENT textAlignment){}
+// Was an empty stub, so TEXT_ALIGN_CENTER / _RIGHT / _CENTER_BOTH were silently
+// drawn left-aligned; drawString() applies the stored alignment now.
+void DisplayWrapper::setTextAlignment(OLEDDISPLAY_TEXT_ALIGNMENT textAlignment){
+	textAlign = textAlignment;
+}
 
 void DisplayWrapper::setFont(int index){
 	setFontIndex(index);


### PR DESCRIPTION
Two more methods that accept what you ask for and then quietly do something else. Both found while working through the Morserino-32 display layer; neither is urgent, since our code already routes around both.

### `getStringWidth()` truncates

It is declared `uint8_t` but returns LovyanGFX's `int32_t textWidth()`, so it wraps modulo 256:

```cpp
uint16_t DisplayWrapper::getStringWidth(const String& strUser){   // was uint8_t
	return lcd.textWidth(strUser);
}
```

A string only has to reach 256 px to be truncated. With the wrapper's own `DialogInput_*` fonts on a 320 px panel — IntelOneMono 12pt/15pt, 15 px and 18 px per character, both strictly monospace — that is about 15 characters, comfortably inside a single line. So it is reachable with ordinary text, and there is no sign it happened: `"Continue with paddle "` measures 315 px and reports 59.

Where the result only feeds a `fillRect()` behind the text the damage is masked, because LovyanGFX's own glyph background boxes fill the same rectangle. Where it feeds column arithmetic it is a real bug — a 15-character chunk reports 0, the caller advances by nothing, and the next chunk overprints it.

Widened to `uint16_t`, which is also what the ThingPulse OLED API this wrapper emulates declares. `getStringHeight()` gets the same treatment for consistency, though it could not realistically overflow.

### `setTextAlignment()` was a stub

It was `{}`, and `drawString()` hard-coded `lgfx::top_left` — so `TEXT_ALIGN_CENTER`, `TEXT_ALIGN_RIGHT` and `TEXT_ALIGN_CENTER_BOTH` were accepted and silently left-aligned. The alignment is now stored and mapped to a datum at draw time:

```cpp
case TEXT_ALIGN_RIGHT:       return lgfx::top_right;
case TEXT_ALIGN_CENTER:      return lgfx::top_center;
case TEXT_ALIGN_CENTER_BOTH: return lgfx::middle_center;
default:                     return lgfx::top_left;
```

following the meaning the OLED library gives them: `CENTER` centres horizontally on `x` and keeps the top edge at `y`; `CENTER_BOTH` centres on both axes.

### Compatibility

Widening a return type is source-compatible — code assigning to a `uint8_t` still compiles and truncates exactly as it does today. The alignment change only reaches callers that were already asking for a non-default alignment and not getting it; every caller in our tree passes `TEXT_ALIGN_LEFT`, which is what the stub already did, so this is behaviour-neutral for us.

Verified by building the Morserino-32 firmware (`pocketwroom`, ESP32-S3 + ST7789) against this branch.
